### PR TITLE
Fix issue where interupts were not being captured in options

### DIFF
--- a/src/System/Console/Repline.hs
+++ b/src/System/Console/Repline.hs
@@ -205,7 +205,7 @@ replLoop banner cmdM opts = loop
 
         Just (':' : cmds) -> do
           let (cmd:args) = words cmds
-          optMatcher cmd opts args
+          H.handleInterrupt (return ()) $ optMatcher cmd opts args
           loop
 
         Just input -> do


### PR DESCRIPTION
If a haskeline interrupt is fired while executing an `Option`, then it will cause the REPL to terminate. This PR changes the behaviour to be more in-line with the `cmd` case.