### PR TITLE
Allow monadic functions to be used when generating banner in REPL

### DIFF
--- a/Example.hs
+++ b/Example.hs
@@ -47,7 +47,7 @@ init1 = return ()
 -- Tab completion inside of StateT
 repl1 :: IO ()
 repl1 = flip evalStateT Set.empty
-      $ evalRepl "_proto> " cmd1 opts1 (Just ':') (Word completer1) init1
+      $ evalRepl (pure "_proto> ") cmd1 opts1 (Just ':') (Word completer1) init1
 
 -------------------------------------------------------------------------------
 -- Command options
@@ -76,7 +76,7 @@ init2 :: Repl2 ()
 init2 = liftIO $ putStrLn "Welcome!"
 
 repl2 :: IO ()
-repl2 = evalRepl "example2> " cmd2 opts2 (Just ':') (Word comp2) init2
+repl2 = evalRepl (pure "example2> ") cmd2 opts2 (Just ':') (Word comp2) init2
 
 -------------------------------------------------------------------------------
 -- Mixed Completion
@@ -119,7 +119,7 @@ init3 :: Repl3 ()
 init3 = return ()
 
 repl3 :: IO ()
-repl3 = evalRepl "example3> " cmd3 opts3 (Just ':') (Prefix (wordCompleter byWord) defaultMatcher) init3
+repl3 = evalRepl (pure "example3> ") cmd3 opts3 (Just ':') (Prefix (wordCompleter byWord) defaultMatcher) init3
 
 -------------------------------------------------------------------------------
 --

--- a/README.md
+++ b/README.md
@@ -43,7 +43,7 @@ ini :: Repl ()
 ini = liftIO $ putStrLn "Welcome!"
 
 repl :: IO ()
-repl = evalRepl ">>> " cmd options (Word completer) ini
+repl = evalRepl (pure ">>> ") cmd options (Word completer) ini
 ```
 
 Trying it out:
@@ -62,9 +62,9 @@ kirk
 "spam"
 
 >>> :say Hello Haskell
- _______________ 
+ _______________
 < Hello Haskell >
- --------------- 
+ ---------------
         \   ^__^
          \  (oo)\_______
             (__)\       )\/\
@@ -113,12 +113,12 @@ ini = return ()
 -- Tab completion inside of StateT
 repl :: IO ()
 repl = flip evalStateT Set.empty
-     $ evalRepl ">>> " cmd opts (Word comp) init
+     $ evalRepl (pure ">>> ") cmd opts (Word comp) init
 ```
 
 
 Prefix Completion
-----------------
+-----------------
 
 Just as GHCi will provide different tab completion for kind-level vs type-level symbols based on which prefix
 the user has entered, we can also set up a provide this as a first-level construct using a ``Prefix`` tab
@@ -164,7 +164,7 @@ init :: Repl ()
 init = return ()
 
 repl :: IO ()
-repl = evalRepl ">> " cmd opts (Prefix (wordCompleter byWord) defaultMatcher) init
+repl = evalRepl (pure ">>> ") cmd opts (Prefix (wordCompleter byWord) defaultMatcher) init
 ```
 
 Trying it out:

--- a/Simple.hs
+++ b/Simple.hs
@@ -37,7 +37,7 @@ ini :: Repl ()
 ini = liftIO $ putStrLn "Welcome!"
 
 repl :: IO ()
-repl = evalRepl ">>> " cmd options (Just ':') (Word0 completer) ini
+repl = evalRepl (pure ">>> ") cmd options (Just ':') (Word0 completer) ini
 
 main :: IO ()
 main = repl

--- a/src/System/Console/Repline.hs
+++ b/src/System/Console/Repline.hs
@@ -72,7 +72,7 @@ The banner function is simply an IO action that is called at the start of the sh
 Putting it all together we have a little shell.
 
 > main :: IO ()
-> main = evalRepl ">>> " cmd options (Word completer) ini
+> main = evalRepl (pure ">>> ") cmd options (Word completer) ini
 
 Putting this in a file we can test out our cow-trek shell.
 
@@ -194,7 +194,7 @@ abort = throwIO H.Interrupt
 
 -- | Completion loop.
 replLoop :: MonadException m
-         => String
+         => HaskelineT m String
          -> Command (HaskelineT m)
          -> Options (HaskelineT m)
          -> Maybe Char
@@ -202,7 +202,8 @@ replLoop :: MonadException m
 replLoop banner cmdM opts optsPrefix = loop
   where
     loop = do
-      minput <- H.handleInterrupt (return (Just "")) $ getInputLine banner
+      prefix <- banner
+      minput <- H.handleInterrupt (return (Just "")) $ getInputLine prefix
       case minput of
         Nothing -> outputStrLn "Goodbye."
 
@@ -229,7 +230,7 @@ optMatcher s ((x, m):xs) args
 
 -- | Evaluate the REPL logic into a MonadException context.
 evalRepl :: MonadException m             -- Terminal monad ( often IO ).
-         => String                       -- ^ Banner
+         => HaskelineT m String          -- ^ Banner
          -> Command (HaskelineT m)       -- ^ Command function
          -> Options (HaskelineT m)       -- ^ Options list and commands
          -> Maybe Char                   -- ^ Optional command prefix ( passing Nothing ignores the Options argument )


### PR DESCRIPTION
Hi,

Here's a small change for allowing monadic operations when constructing the banner in the REPL.
My usecase for this is to include a line number in the banner (e.g. `1> ...`, `2> ...`) if you combine HaskelineT with StateT.
But it could be used for other things too potentially.

Interface changes though: if you need no effects, you now need to wrap the banner argument in `pure` or `return`.