### PR TITLE
Allow containers 0.6, as released with GHC 8.6.

### DIFF
--- a/repline.cabal
+++ b/repline.cabal
@@ -26,7 +26,7 @@ library
   exposed-modules:     System.Console.Repline
   build-depends:
     base       >= 4.6 && <5.0,
-    containers >= 0.5 && <0.6,
+    containers >= 0.5 && <0.7,
     mtl        >= 2.2 && <2.3,
     process    >= 1.2 && <2.0,
     haskeline  >= 0.7 && <0.8


### PR DESCRIPTION
After this is merged, a release or a revision would be handy, please.