### PR TITLE
depend on fail only for ghc7

### DIFF
--- a/repline.cabal
+++ b/repline.cabal
@@ -31,9 +31,10 @@ library
   build-depends:
     base       >= 4.6 && <5.0,
     containers >= 0.5 && <0.7,
-    fail       >= 4.9 && <4.10,
     exceptions >= 0.10 && < 0.11,
     mtl        >= 2.2 && <2.3,
     process    >= 1.2 && <2.0,
     haskeline  >= 0.7 && <0.9
+  if !impl(ghc >= 8.0)
+    Build-Depends: fail >= 4.9 && <4.10
   default-language:    Haskell2010


### PR DESCRIPTION
For ghc8 `fail` is just a dummy dependency