### PR TITLE
Add finaliser to ReplOpts

### DIFF
--- a/Example.hs
+++ b/Example.hs
@@ -43,11 +43,14 @@ opts1 =
 init1 :: Repl1 ()
 init1 = return ()
 
+final1 :: Repl1 ExitDecision
+final1 = return Exit
+
 -- Tab completion inside of StateT
 repl1 :: IO ()
 repl1 =
   flip evalStateT Set.empty $
-    evalRepl (pure "_proto> ") cmd1 opts1 (Just ':') (Word completer1) init1
+    evalRepl (pure "_proto> ") cmd1 opts1 (Just ':') (Word completer1) init1 final1
 
 -------------------------------------------------------------------------------
 -- Command options
@@ -75,8 +78,13 @@ opts2 =
 init2 :: Repl2 ()
 init2 = liftIO $ putStrLn "Welcome!"
 
+final2 :: Repl2 ExitDecision
+final2 = do
+  liftIO $ putStrLn "Goodbye!"
+  return Exit
+
 repl2 :: IO ()
-repl2 = evalRepl (pure "example2> ") cmd2 opts2 (Just ':') (Word comp2) init2
+repl2 = evalRepl (pure "example2> ") cmd2 opts2 (Just ':') (Word comp2) init2 final2
 
 -------------------------------------------------------------------------------
 -- Mixed Completion
@@ -118,8 +126,11 @@ opts3 =
 init3 :: Repl3 ()
 init3 = return ()
 
+final3 :: Repl3 ExitDecision
+final3 = return Exit
+
 repl3 :: IO ()
-repl3 = evalRepl (pure "example3> ") cmd3 opts3 (Just ':') (Prefix (wordCompleter byWord) defaultMatcher) init3
+repl3 = evalRepl (pure "example3> ") cmd3 opts3 (Just ':') (Prefix (wordCompleter byWord) defaultMatcher) init3 final3
 
 -------------------------------------------------------------------------------
 --

--- a/examples/Prefix.hs
+++ b/examples/Prefix.hs
@@ -51,8 +51,11 @@ opts =
 inits :: Repl ()
 inits = return ()
 
+final :: Repl ExitDecision
+final = return Exit
+
 repl :: IO ()
-repl = evalRepl (pure ">>> ") cmd opts Nothing (Prefix (wordCompleter byWord) defaultMatcher) inits
+repl = evalRepl (pure ">>> ") cmd opts Nothing (Prefix (wordCompleter byWord) defaultMatcher) inits final
 
 main :: IO ()
 main = pure ()

--- a/examples/Simple.hs
+++ b/examples/Simple.hs
@@ -35,6 +35,11 @@ opts =
 ini :: Repl ()
 ini = liftIO $ putStrLn "Welcome!"
 
+final :: Repl ExitDecision
+final = do
+  liftIO $ putStrLn "Goodbye!"
+  return Exit
+
 repl_alt :: IO ()
 repl_alt = evalReplOpts $ ReplOpts
   { banner      = pure ">>> "
@@ -43,10 +48,11 @@ repl_alt = evalReplOpts $ ReplOpts
   , prefix      = Just ':'
   , tabComplete = (Word0 completer)
   , initialiser = ini
+  , finaliser   = final
   }
 
 repl :: IO ()
-repl = evalRepl (pure ">>> ") cmd opts (Just ':') (Word0 completer) ini
+repl = evalRepl (pure ">>> ") cmd opts (Just ':') (Word0 completer) ini final
 
 main :: IO ()
 main = pure ()

--- a/examples/Stateful.hs
+++ b/examples/Stateful.hs
@@ -43,11 +43,14 @@ opts =
 ini :: Repl ()
 ini = return ()
 
+final :: Repl ExitDecision
+final = return Exit
+
 -- Tab completion inside of StateT
 repl :: IO ()
 repl =
   flip evalStateT Set.empty $
-    evalRepl (pure ">>> ") cmd opts Nothing (Word comp) ini
+    evalRepl (pure ">>> ") cmd opts Nothing (Word comp) ini final
 
 main :: IO ()
 main = pure ()


### PR DESCRIPTION
This finaliser gives more control for handling <Ctrl-D> to the user of the
library:

- The exit message can be customised
- <Ctrl-D> can be used for something else than exit depending on the
  application state (for example to implement multi-line inputs on top of
  `repline`)

Note:
I intend on using this feature to implement multi-line support for the Dhall REPL
https://github.com/dhall-lang/dhall-haskell/issues/1680