### PR TITLE
Add multi-line input support

### DIFF
--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -1,6 +1,8 @@
 HEAD
 ====
 
+- Add multi-line input support
+
 0.3.0.0
 =======
 

--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -2,6 +2,7 @@ HEAD
 ====
 
 - Add multi-line input support
+- Add finaliser option to control REPL exit on <Ctrl-D>
 
 0.3.0.0
 =======

--- a/Example.hs
+++ b/Example.hs
@@ -50,7 +50,7 @@ final1 = return Exit
 repl1 :: IO ()
 repl1 =
   flip evalStateT Set.empty $
-    evalRepl (pure "_proto> ") cmd1 opts1 (Just ':') (Word completer1) init1 final1
+    evalRepl (const $ pure "_proto> ") cmd1 opts1 (Just ':') Nothing (Word completer1) init1 final1
 
 -------------------------------------------------------------------------------
 -- Command options
@@ -84,7 +84,7 @@ final2 = do
   return Exit
 
 repl2 :: IO ()
-repl2 = evalRepl (pure "example2> ") cmd2 opts2 (Just ':') (Word comp2) init2 final2
+repl2 = evalRepl (const $ pure "example2> ") cmd2 opts2 (Just ':') Nothing (Word comp2) init2 final2
 
 -------------------------------------------------------------------------------
 -- Mixed Completion
@@ -130,7 +130,7 @@ final3 :: Repl3 ExitDecision
 final3 = return Exit
 
 repl3 :: IO ()
-repl3 = evalRepl (pure "example3> ") cmd3 opts3 (Just ':') (Prefix (wordCompleter byWord) defaultMatcher) init3 final3
+repl3 = evalRepl (const $ pure "example3> ") cmd3 opts3 (Just ':') Nothing (Prefix (wordCompleter byWord) defaultMatcher) init3 final3
 
 -------------------------------------------------------------------------------
 --

--- a/examples/Prefix.hs
+++ b/examples/Prefix.hs
@@ -55,7 +55,7 @@ final :: Repl ExitDecision
 final = return Exit
 
 repl :: IO ()
-repl = evalRepl (pure ">>> ") cmd opts Nothing (Prefix (wordCompleter byWord) defaultMatcher) inits final
+repl = evalRepl (const $ pure ">>> ") cmd opts Nothing Nothing (Prefix (wordCompleter byWord) defaultMatcher) inits final
 
 main :: IO ()
 main = pure ()

--- a/examples/Simple.hs
+++ b/examples/Simple.hs
@@ -42,17 +42,22 @@ final = do
 
 repl_alt :: IO ()
 repl_alt = evalReplOpts $ ReplOpts
-  { banner      = pure ">>> "
-  , command     = cmd
-  , options     = opts
-  , prefix      = Just ':'
-  , tabComplete = (Word0 completer)
-  , initialiser = ini
-  , finaliser   = final
+  { banner           = const $ pure ">>> "
+  , command          = cmd
+  , options          = opts
+  , prefix           = Just ':'
+  , multilineCommand = Just "paste"
+  , tabComplete      = (Word0 completer)
+  , initialiser      = ini
+  , finaliser        = final
   }
 
+customBanner :: MultiLine -> Repl String
+customBanner SingleLine = pure ">>> "
+customBanner MultiLine = pure "| "
+
 repl :: IO ()
-repl = evalRepl (pure ">>> ") cmd opts (Just ':') (Word0 completer) ini final
+repl = evalRepl (const $ pure ">>> ") cmd opts (Just ':') (Just "paste") (Word0 completer) ini final
 
 main :: IO ()
 main = pure ()

--- a/examples/Stateful.hs
+++ b/examples/Stateful.hs
@@ -50,7 +50,7 @@ final = return Exit
 repl :: IO ()
 repl =
   flip evalStateT Set.empty $
-    evalRepl (pure ">>> ") cmd opts Nothing (Word comp) ini final
+    evalRepl (const $ pure ">>> ") cmd opts Nothing Nothing (Word comp) ini final
 
 main :: IO ()
 main = pure ()


### PR DESCRIPTION
The way this multi-line input works is very much inspired by the PureScript REPL which also uses `haskeline`:
https://github.com/purescript/purescript/issues/934#issuecomment-80525135

The name of the command is configurable, so it could be called `m`, `paste`, `multiline`, or whatever works best for the application using this.

The banner can now take into account if it's in the middle of a multi-line input or not.

This PR might make #25 redundant.