### PR TITLE
0.4: Add support for multi-line commands

### DIFF
--- a/Example.hs
+++ b/Example.hs
@@ -34,10 +34,10 @@ help1 args = liftIO $ print $ "Help!" ++ show args
 puts1 :: [String] -> Repl1 ()
 puts1 args = modify $ Set.union (Set.fromList args)
 
-opts1 :: [(String, [String] -> Repl1 ())]
+opts1 :: [(String, String -> Repl1 ())]
 opts1 =
-  [ ("help", help1), -- :help
-    ("puts", puts1) -- :puts
+  [ ("help", help1 . words), -- :help
+    ("puts", puts1 . words) -- :puts
   ]
 
 init1 :: Repl1 ()
@@ -70,9 +70,9 @@ comp2 = listWordCompleter ["kirk", "spock", "mccoy"]
 help2 :: [String] -> Repl2 ()
 help2 args = liftIO $ print $ "Help!" ++ show args
 
-opts2 :: [(String, [String] -> Repl2 ())]
+opts2 :: [(String, String -> Repl2 ())]
 opts2 =
-  [ ("help", help2)
+  [ ("help", help2 . words)
   ]
 
 init2 :: Repl2 ()
@@ -107,17 +107,17 @@ byWord n = do
   let names = ["picard", "riker", "data", ":file", ":holiday"]
   return $ filter (isPrefixOf n) names
 
-files :: [String] -> Repl3 ()
+files :: String -> Repl3 ()
 files args = liftIO $ do
-  contents <- readFile (unwords args)
+  contents <- readFile args
   putStrLn contents
 
-holidays :: [String] -> Repl3 ()
-holidays [] = liftIO $ putStrLn "Enter a holiday."
+holidays :: String -> Repl3 ()
+holidays "" = liftIO $ putStrLn "Enter a holiday."
 holidays xs = liftIO $ do
-  putStrLn $ "Happy " ++ unwords xs ++ "!"
+  putStrLn $ "Happy " ++ xs ++ "!"
 
-opts3 :: [(String, [String] -> Repl3 ())]
+opts3 :: [(String, String -> Repl3 ())]
 opts3 =
   [ ("file", files),
     ("holiday", holidays)

--- a/examples/Prefix.hs
+++ b/examples/Prefix.hs
@@ -32,17 +32,17 @@ byWord n = do
   let names = ["picard", "riker", "data", ":file", ":holiday"]
   return $ filter (isPrefixOf n) names
 
-files :: [String] -> Repl ()
+files :: String -> Repl ()
 files args = liftIO $ do
-  contents <- readFile (unwords args)
+  contents <- readFile args
   putStrLn contents
 
-holidays :: [String] -> Repl ()
-holidays [] = liftIO $ putStrLn "Enter a holiday."
+holidays :: String -> Repl ()
+holidays "" = liftIO $ putStrLn "Enter a holiday."
 holidays xs = liftIO $ do
-  putStrLn $ "Happy " ++ unwords xs ++ "!"
+  putStrLn $ "Happy " ++ xs ++ "!"
 
-opts :: [(String, [String] -> Repl ())]
+opts :: [(String, String -> Repl ())]
 opts =
   [ ("file", files),
     ("holiday", holidays)

--- a/examples/Simple.hs
+++ b/examples/Simple.hs
@@ -21,14 +21,14 @@ completer n = do
 help :: [String] -> Repl ()
 help args = liftIO $ print $ "Help: " ++ show args
 
-say :: [String] -> Repl ()
+say :: String -> Repl ()
 say args = do
-  _ <- liftIO $ callCommand $ "cowsay" ++ " " ++ (unwords args)
+  _ <- liftIO $ callCommand $ "cowsay" ++ " " ++ args
   return ()
 
-opts :: [(String, [String] -> Repl ())]
+opts :: [(String, String -> Repl ())]
 opts =
-  [ ("help", help), -- :help
+  [ ("help", help . words), -- :help
     ("say", say) -- :say
   ]
 

--- a/examples/Stateful.hs
+++ b/examples/Stateful.hs
@@ -34,10 +34,10 @@ help args = liftIO $ print $ "Help!" ++ show args
 puts :: [String] -> Repl ()
 puts args = modify . fmap $ \s -> Set.union s (Set.fromList args)
 
-opts :: [(String, [String] -> Repl ())]
+opts :: [(String, String -> Repl ())]
 opts =
-  [ ("help", help), -- :help
-    ("puts", puts) -- :puts
+  [ ("help", help . words), -- :help
+    ("puts", puts . words) -- :puts
   ]
 
 ini :: Repl ()


### PR DESCRIPTION
While commands already work with multi-line inputs, the commands cannot 
 distinguish between a space and newline character since the arguments the
 function receives are already split by word.

 This commit changes this and provides the raw argument string to the 
 command function.