### PR TITLE
nix: Don't use sha256 when using nixpkgs-channels

### DIFF
--- a/nixpkgs.nix
+++ b/nixpkgs.nix
@@ -1,4 +1,1 @@
-import (fetchTarball {
-  url = https://github.com/NixOS/nixpkgs-channels/archive/nixos-20.03.tar.gz;
-  sha256 = "sha256:10dwzdari9zjmqciccyyymmsj6zr5s76s9yqgs6ipshyfkkx7hrc";
-})
+import (fetchTarball "https://github.com/NixOS/nixpkgs-channels/archive/nixos-20.03.tar.gz")


### PR DESCRIPTION
This is less reproducible, but since we are not pinning a specific revision using the sha is unlikely to keep on working