### PR TITLE
Export MonadHaskell methods

### DIFF
--- a/src/System/Console/Repline.hs
+++ b/src/System/Console/Repline.hs
@@ -136,7 +136,7 @@ module System.Console.Repline
   ( -- * Repline Monad
     HaskelineT,
     runHaskelineT,
-    MonadHaskeline,
+    MonadHaskeline(..),
 
     -- * Toplevel
     evalRepl,


### PR DESCRIPTION
As discussed in issue #36, the methods of MonadHaskell are actually useful.
A previous commit only exported the class without methods.

In particular, getInput{Line,Char} can be useful for small dialogs in
commands.
