### PR TITLE
Fix warning: [GHC-39567] [-Wstar-is-type]

### DIFF
--- a/repline.cabal
+++ b/repline.cabal
@@ -41,7 +41,7 @@ library
   exposed-modules:  System.Console.Repline
   ghc-options:      -Wall
   build-depends:
-      base        >=4.6  && <5.0
+      base        >=4.9  && <5.0
     , containers  >=0.5  && <0.7
     , exceptions  >=0.10 && <0.11
     , haskeline   >=0.8  && <0.9

--- a/src/System/Console/Repline.hs
+++ b/src/System/Console/Repline.hs
@@ -176,6 +176,7 @@ import Control.Monad.Fix (MonadFix)
 import Control.Monad.IO.Class (MonadIO(..))
 import Control.Monad.Reader
 import Control.Monad.State.Strict
+import Data.Kind (Type)
 import Data.List (isPrefixOf)
 import qualified System.Console.Haskeline as H
 import System.Console.Haskeline.Completion
@@ -185,7 +186,7 @@ import System.Console.Haskeline.Completion
 -------------------------------------------------------------------------------
 
 -- | Monad transformer for readline input
-newtype HaskelineT (m :: * -> *) a = HaskelineT {unHaskeline :: H.InputT m a}
+newtype HaskelineT (m :: Type -> Type) a = HaskelineT {unHaskeline :: H.InputT m a}
   deriving
     ( Monad,
       Functor,


### PR DESCRIPTION
Using ‘*’ (or its Unicode variant) to mean ‘Data.Kind.Type’
relies on the StarIsType extension, which will become
deprecated in the future.

Suggested fix: Use ‘Type’ from ‘Data.Kind’ instead.
