### PR TITLE
Allow `containers` 0.7

### DIFF
--- a/repline.cabal
+++ b/repline.cabal
@@ -42,7 +42,7 @@ library
   ghc-options:      -Wall
   build-depends:
       base        >=4.6  && <5.0
-    , containers  >=0.5  && <0.7
+    , containers  >=0.5  && <0.8
     , exceptions  >=0.10 && <0.11
     , haskeline   >=0.8  && <0.9
     , mtl         >=2.2  && <2.4


### PR DESCRIPTION
This is all that's needed for GHC 9.10 compatibility.