### PR TITLE
update ci

### DIFF
--- a/.github/workflows/cabal.yml
+++ b/.github/workflows/cabal.yml
@@ -9,21 +9,21 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        ghc: ['9.2', '9.0.1', '8.10.7', '8.10.1', '8.8.1', '8.6.5', '8.6.4', '8.6.3', '8.6.2', '8.4.4', '8.2.2']
-        cabal: ['latest', 3.2]
+        ghc: ['9.12', '9.10', '9.8', '9.6', '9.4', '9.2', '9.0', '8.10', '8.8', '8.6', '8.4', '8.2']
+        cabal: ['latest']
       fail-fast: false
     env:
       CONFIG: "--enable-tests --enable-benchmarks"
     steps:
-      - uses: actions/checkout@v2
-      - uses: haskell/actions/setup@v1.2
+      - uses: actions/checkout@v4
+      - uses: haskell-actions/setup@v2
         id: setup-haskell-cabal
         with:
           ghc-version: ${{ matrix.ghc }}
           cabal-version: ${{ matrix.cabal }}
       - run: cabal v2-update
       - run: cabal v2-freeze $CONFIG
-      - uses: actions/cache@v2
+      - uses: actions/cache@v4
         with:
           path: |
             ${{ steps.setuphaskell-cabal.outputs.cabal-store }}

--- a/repline.cabal
+++ b/repline.cabal
@@ -42,12 +42,12 @@ library
   exposed-modules:  System.Console.Repline
   ghc-options:      -Wall
   build-depends:
-      base        >=4.6  && <5.0
+      base        >=4.6  && <5
     , containers  >=0.5  && <0.8
     , exceptions  >=0.10 && <0.11
     , haskeline   >=0.8  && <0.9
     , mtl         >=2.2  && <2.4
-    , process     >=1.2  && <2.0
+    , process     >=1.2  && <2
 
   if !impl(ghc >=8.0)
     build-depends: fail ==4.9.*

--- a/repline.cabal
+++ b/repline.cabal
@@ -13,15 +13,16 @@ cabal-version:      >=1.10
 tested-with:
   GHC ==8.2.2
    || ==8.4.4
-   || ==8.6.2
-   || ==8.6.3
-   || ==8.6.4
    || ==8.6.5
-   || ==8.8.1
-   || ==8.10.1
+   || ==8.8.4
    || ==8.10.7
-   || ==9.0.1
-   || ==9.2
+   || ==9.0.2
+   || ==9.2.8
+   || ==9.4.8
+   || ==9.6.7
+   || ==9.8.4
+   || ==9.10.2
+   || ==9.12.2
 
 homepage:           https://github.com/sdiehl/repline
 bug-reports:        https://github.com/sdiehl/repline/issues


### PR DESCRIPTION
- **Update CI to 5 new GHC major versions**
  

- **Fix upper bounds, e.g. <5 instead of <5.0**
  <5.0 allows ==5, which is not what is usually intended.
  Correct is <5.
  
CI running here: https://github.com/andreasabel/repline/pull/1